### PR TITLE
fix for Kubernetes 1.16 which lacks apps/v1beta1

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -53,7 +53,6 @@ func (w *Watcher) Start(ctx context.Context) {
 		w.factory.Core().V1().Nodes().Informer(),
 		w.factory.Core().V1().Namespaces().Informer(),
 		w.factory.Core().V1().Pods().Informer(),
-		w.factory.Apps().V1beta1().Deployments().Informer(),
 	}
 
 	for _, informer := range informers {


### PR DESCRIPTION
The agent doesn't yet support deployments anyway. I don't know why we
were setting up an informer for them. We'll figure out how to handle
alternate API namespaces for them when we add support for deployments.

Refs ZPS-6406.