### PR TITLE
simpleCustomRelationship*Tag -> impact*Dimensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest AS certs
 RUN apk --no-cache --update add ca-certificates
 
 # Build using the appropriate Alpine golang image.
-FROM golang:1.12-alpine AS build
+FROM golang:1.13-alpine AS build
 
 # Install build toolchain dependencies.
 RUN apk --no-cache add git

--- a/README.markdown
+++ b/README.markdown
@@ -423,12 +423,10 @@ The agent will send a cluster model to Zenoss each time it starts.
 
 #### Cluster Metadata
 
-| Field                               | Value                       |
-| ----------------------------------- | --------------------------- |
-| `name`                              | `<clusterName>`             |
-| `type`                              | `k8s.cluster`               |
-| `simpleCustomRelationshipSourceTag` | `k8s.cluster=<clusterName>` |
-| `simpleCustomRelationshipSinkTag`   | `k8s.cluster=<clusterName>` |
+| Field  | Value           |
+| ------ | --------------- |
+| `name` | `<clusterName>` |
+| `type` | `k8s.cluster`   |
 
 #### Cluster Metrics
 
@@ -460,12 +458,11 @@ change.
 
 #### Node Metadata
 
-| Field                               | Value                                                                        |
-| ----------------------------------- | ---------------------------------------------------------------------------- |
-| `name`                              | `<nodeName>`                                                                 |
-| `type`                              | `k8s.node`                                                                   |
-| `simpleCustomRelationshipSourceTag` | `k8s.cluster=<clusterName>,k8s.node=<nodeName>`, `k8s.cluster=<clusterName>` |
-| `simpleCustomRelationshipSinkTag`   | `k8s.cluster=<clusterName>,k8s.node=<nodeName>`                              |
+| Field           | Value                       |
+| --------------- | --------------------------- |
+| `name`          | `<nodeName>`                |
+| `type`          | `k8s.node`                  |
+| `impactToField` | `k8s.cluster=<clusterName>` |
 
 #### Node Metrics
 
@@ -493,12 +490,11 @@ namespace's properties change.
 
 #### Namespace Metadata
 
-| Field                               | Value                                                                                  |
-| ----------------------------------- | -------------------------------------------------------------------------------------- |
-| `name`                              | `<namespaceName>`                                                                      |
-| `type`                              | `k8s.namespace`                                                                        |
-| `simpleCustomRelationshipSourceTag` | `k8s.cluster=<clusterName>,k8s.namespace=<namespaceName>`                              |
-| `simpleCustomRelationshipSinkTag`   | `k8s.cluster=<clusterName>,k8s.namespace=<namespaceName>`, `k8s.cluster=<clusterName>` |
+| Field             | Value                       |
+| ----------------- | --------------------------- |
+| `name`            | `<namespaceName>`           |
+| `type`            | `k8s.namespace`             |
+| `impactFromField` | `k8s.cluster=<clusterName>` |
 
 #### Namespace Metrics
 
@@ -529,12 +525,11 @@ again for each pod anytime the pod's properties change.
 
 #### Pod Metadata
 
-| Field                               | Value                                                                                                                                                                                   |
-| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                              | `<podName>`                                                                                                                                                                             |
-| `type`                              | `k8s.pod`                                                                                                                                                                               |
-| `simpleCustomRelationshipSourceTag` | `k8s.cluster=<clusterName>,k8s.namespace=<namespaceName>,k8s.pod=<podName>`                                                                                                             |
-| `simpleCustomRelationshipSinkTag`   | `k8s.cluster=<clusterName>,k8s.namespace=<namespaceName>,k8s.pod=<podName>`, `k8s.cluster=<clusterName>,k8s.node=<nodeName>`, `k8s.cluster=<clusterName>,k8s.namespace=<namespaceName>` |
+| Field             | Value                                                                                                      |
+| ----------------- | ---------------------------------------------------------------------------------------------------------- |
+| `name`            | `<podName>`                                                                                                |
+| `type`            | `k8s.pod`                                                                                                  |
+| `impactFromField` | `k8s.cluster=<clusterName>,k8s.namespace=<namespaceName>`, `k8s.cluster=<clusterName>,k8s.node=<nodeName>` |
 
 #### Pod Metrics
 
@@ -566,12 +561,11 @@ the container's pod's properties change.
 
 #### Container Metadata
 
-| Field                               | Value                                                                                                                                                                                  |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                              | `<containerName>`                                                                                                                                                                      |
-| `type`                              | `k8s.container`                                                                                                                                                                        |
-| `simpleCustomRelationshipSourceTag` | `k8s.cluster=<clusterName>,k8s.namespace=<namespaceName>,k8s.pod=<podName>,k8s.container=<containerName>`, `k8s.cluster=<clusterName>,k8s.namespace=<namespaceName>,k8s.pod=<podName>` |
-| `simpleCustomRelationshipSinkTag`   | `k8s.cluster=<clusterName>,k8s.namespace=<namespaceName>,k8s.pod=<podName>,k8s.container=<containerName>`                                                                              |
+| Field                | Value                                                                       |
+| -------------------- | --------------------------------------------------------------------------- |
+| `name`               | `<containerName>`                                                           |
+| `type`               | `k8s.container`                                                             |
+| `impactToDimensions` | `k8s.cluster=<clusterName>,k8s.namespace=<namespaceName>,k8s.pod=<podName>` |
 
 #### Container Metrics
 

--- a/main.go
+++ b/main.go
@@ -41,8 +41,8 @@ const (
 
 	zenossSourceTypeField    = "source-type"
 	zenossSourceField        = "source"
-	zenossSCRSourceTagField  = "simpleCustomRelationshipSourceTag"
-	zenossSCRSinkTagField    = "simpleCustomRelationshipSinkTag"
+	zenossImpactFromField    = "impactFromDimensions"
+	zenossImpactToField      = "impactToDimensions"
 	zenossNameField          = "name"
 	zenossTypeField          = "type"
 	zenossEntityDeletedField = "_zen_deleted_entity"

--- a/watch_test.go
+++ b/watch_test.go
@@ -51,10 +51,6 @@ func TestWatcher_addCluster(t *testing.T) {
 				Fields: map[string]*structpb.Value{
 					"name": valueFromString(testClusterName),
 					"type": valueFromString("k8s.cluster"),
-					"simpleCustomRelationshipSourceTag": valueFromStringSlice(
-						[]string{fmt.Sprintf("k8s.cluster=%s", testClusterName)}),
-					"simpleCustomRelationshipSinkTag": valueFromStringSlice(
-						[]string{fmt.Sprintf("k8s.cluster=%s", testClusterName)}),
 				},
 			},
 		}, clusterModel)
@@ -90,14 +86,9 @@ func TestWatcher_handleResource(t *testing.T) {
 					Fields: map[string]*structpb.Value{
 						"name": valueFromString("node1"),
 						"type": valueFromString("k8s.node"),
-						"simpleCustomRelationshipSourceTag": valueFromStringSlice(
+						"impactToDimensions": valueFromStringSlice(
 							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.node=node1", testClusterName),
 								fmt.Sprintf("k8s.cluster=%s", testClusterName),
-							}),
-						"simpleCustomRelationshipSinkTag": valueFromStringSlice(
-							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.node=node1", testClusterName),
 							}),
 					},
 				},
@@ -124,14 +115,9 @@ func TestWatcher_handleResource(t *testing.T) {
 					Fields: map[string]*structpb.Value{
 						"name": valueFromString("node1"),
 						"type": valueFromString("k8s.node"),
-						"simpleCustomRelationshipSourceTag": valueFromStringSlice(
+						"impactToDimensions": valueFromStringSlice(
 							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.node=node1", testClusterName),
 								fmt.Sprintf("k8s.cluster=%s", testClusterName),
-							}),
-						"simpleCustomRelationshipSinkTag": valueFromStringSlice(
-							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.node=node1", testClusterName),
 							}),
 						"_zen_deleted_entity": valueFromBool(true),
 					},
@@ -159,13 +145,8 @@ func TestWatcher_handleResource(t *testing.T) {
 					Fields: map[string]*structpb.Value{
 						"name": valueFromString("default"),
 						"type": valueFromString("k8s.namespace"),
-						"simpleCustomRelationshipSourceTag": valueFromStringSlice(
+						"impactFromDimensions": valueFromStringSlice(
 							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default", testClusterName),
-							}),
-						"simpleCustomRelationshipSinkTag": valueFromStringSlice(
-							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default", testClusterName),
 								fmt.Sprintf("k8s.cluster=%s", testClusterName),
 							}),
 					},
@@ -193,13 +174,8 @@ func TestWatcher_handleResource(t *testing.T) {
 					Fields: map[string]*structpb.Value{
 						"name": valueFromString("default"),
 						"type": valueFromString("k8s.namespace"),
-						"simpleCustomRelationshipSourceTag": valueFromStringSlice(
+						"impactFromDimensions": valueFromStringSlice(
 							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default", testClusterName),
-							}),
-						"simpleCustomRelationshipSinkTag": valueFromStringSlice(
-							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default", testClusterName),
 								fmt.Sprintf("k8s.cluster=%s", testClusterName),
 							}),
 						"_zen_deleted_entity": valueFromBool(true),
@@ -242,13 +218,8 @@ func TestWatcher_handleResource(t *testing.T) {
 					Fields: map[string]*structpb.Value{
 						"name": valueFromString("pod1"),
 						"type": valueFromString("k8s.pod"),
-						"simpleCustomRelationshipSourceTag": valueFromStringSlice(
+						"impactFromDimensions": valueFromStringSlice(
 							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default,k8s.pod=pod1", testClusterName),
-							}),
-						"simpleCustomRelationshipSinkTag": valueFromStringSlice(
-							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default,k8s.pod=pod1", testClusterName),
 								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default", testClusterName),
 								fmt.Sprintf("k8s.cluster=%s,k8s.node=node1", testClusterName),
 							}),
@@ -268,14 +239,9 @@ func TestWatcher_handleResource(t *testing.T) {
 					Fields: map[string]*structpb.Value{
 						"name": valueFromString("container1"),
 						"type": valueFromString("k8s.container"),
-						"simpleCustomRelationshipSourceTag": valueFromStringSlice(
+						"impactToDimensions": valueFromStringSlice(
 							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default,k8s.pod=pod1,k8s.container=container1", testClusterName),
 								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default,k8s.pod=pod1", testClusterName),
-							}),
-						"simpleCustomRelationshipSinkTag": valueFromStringSlice(
-							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default,k8s.pod=pod1,k8s.container=container1", testClusterName),
 							}),
 					},
 				},
@@ -316,13 +282,8 @@ func TestWatcher_handleResource(t *testing.T) {
 					Fields: map[string]*structpb.Value{
 						"name": valueFromString("pod1"),
 						"type": valueFromString("k8s.pod"),
-						"simpleCustomRelationshipSourceTag": valueFromStringSlice(
+						"impactFromDimensions": valueFromStringSlice(
 							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default,k8s.pod=pod1", testClusterName),
-							}),
-						"simpleCustomRelationshipSinkTag": valueFromStringSlice(
-							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default,k8s.pod=pod1", testClusterName),
 								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default", testClusterName),
 								fmt.Sprintf("k8s.cluster=%s,k8s.node=node1", testClusterName),
 							}),
@@ -343,14 +304,9 @@ func TestWatcher_handleResource(t *testing.T) {
 					Fields: map[string]*structpb.Value{
 						"name": valueFromString("container1"),
 						"type": valueFromString("k8s.container"),
-						"simpleCustomRelationshipSourceTag": valueFromStringSlice(
+						"impactToDimensions": valueFromStringSlice(
 							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default,k8s.pod=pod1,k8s.container=container1", testClusterName),
 								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default,k8s.pod=pod1", testClusterName),
-							}),
-						"simpleCustomRelationshipSinkTag": valueFromStringSlice(
-							[]string{
-								fmt.Sprintf("k8s.cluster=%s,k8s.namespace=default,k8s.pod=pod1,k8s.container=container1", testClusterName),
 							}),
 						"_zen_deleted_entity": valueFromBool(true),
 					},


### PR DESCRIPTION
Change from using simpleCustomRelationship(Sink|Source)Tag metadata
fields to impact(From|To)Dimensions. This is simpler on the agent side,
and more performant on the ingest policy side.

Refs ZPS-6503.